### PR TITLE
Height fix.

### DIFF
--- a/src/rcl/PanTable.jsx
+++ b/src/rcl/PanTable.jsx
@@ -185,7 +185,7 @@ export default function PanTable({columns, rows, defaultFilter, setDefaultFilter
                 </Typography>
             </Toolbar>}
             <Paper sx={{ width: '100%', overflow: 'hidden' }}>
-                <TableContainer sx={{ maxHeight: { sm: 140, md: 170, lg: 200, xl: 250 } }}>
+                <TableContainer>
                     <Table stickyHeader aria-label="pan table" sx={{ tableLayout: 'fixed' }}>
                         <EnhancedTableHead
                             numSelected={selected.length}


### PR DESCRIPTION
Should I make the tablee height: "100%"? As of now it's only expanding to 100% if the content of the table surpasses that, so if the table has little content if won't expand fully. 

I removed the fixed heights and questioning if we should force the table to expand to 100% all the time, it could also be something we change with the properties, like fullHeight or (it also 100% width by default).